### PR TITLE
Checks and refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 pyawair/secret.py
 
 tests/secret.py
+tests/config.py

--- a/pyawair/conn.py
+++ b/pyawair/conn.py
@@ -1,7 +1,6 @@
 import requests
 import ast
 import json
-from pyawair.auth import *
 
 def check_response(response):
     if response.status_code != 200:

--- a/pyawair/conn.py
+++ b/pyawair/conn.py
@@ -1,0 +1,17 @@
+import requests
+import ast
+import json
+from pyawair.auth import *
+
+def check_response(response):
+    if response.status_code != 200:
+        raise ConnectionError("No connection with the API. Status code {}. Message: '{}'.".format(response.status_code,
+                                                                                               ast.literal_eval(response.text)['message']))
+    return
+
+def get_data(auth, id, type, base_url, data_url):
+    dev_url = type + "/" + str(id)
+    f_url = base_url + dev_url + data_url
+    response = requests.get(f_url, headers=auth.headers)
+    check_response(response)
+    return json.loads(response.text)['data']

--- a/pyawair/data.py
+++ b/pyawair/data.py
@@ -1,6 +1,6 @@
 from pyawair.devices import *
 import pyawair.conn
-from pyawair.objects import *
+import pyawair.objects
 
 
 def get_current_air_data(auth, device_name=None, device_type=None, device_id=None):
@@ -14,7 +14,7 @@ def get_current_air_data(auth, device_name=None, device_type=None, device_id=Non
     :return: Object of Dict type which contains current air data
     """
     if device_type is None or device_id is None:
-        awair_device = AwairDev(device_name, auth)
+        awair_device = pyawair.objects.AwairDev(device_name, auth)
         device_type = awair_device.type()
         device_id = awair_device.id()
 
@@ -36,7 +36,7 @@ def get_5_min_average(auth, device_name=None, device_type=None, device_id=None):
     :return: Object of Dict type which contains current air data
     """
     if device_type is None or device_id is None:
-        awair_device = AwairDev(device_name, auth)
+        awair_device = pyawair.objects.AwairDev(device_name, auth)
         device_type = awair_device.type()
         device_id = awair_device.id()
 
@@ -58,7 +58,7 @@ def get_15_min_average(auth, device_name=None, device_type=None, device_id=None)
     :return: Object of Dict type which contains current air data
     """
     if device_type is None or device_id is None:
-        awair_device = AwairDev(device_name, auth)
+        awair_device = pyawair.objects.AwairDev(device_name, auth)
         device_type = awair_device.type()
         device_id = awair_device.id()
 
@@ -80,7 +80,7 @@ def get_raw_data(auth, device_name=None, device_type=None, device_id=None):
         :return: Object of Dict type which contains current air data
         """
     if device_type is None or device_id is None:
-        awair_device = AwairDev(device_name, auth)
+        awair_device = pyawair.objects.AwairDev(device_name, auth)
         device_type = awair_device.type()
         device_id = awair_device.id()
 

--- a/pyawair/data.py
+++ b/pyawair/data.py
@@ -1,4 +1,6 @@
 from pyawair.devices import *
+import pyawair.conn
+from pyawair.objects import *
 
 
 def get_current_air_data(auth, device_name=None, device_type=None, device_id=None):
@@ -11,88 +13,79 @@ def get_current_air_data(auth, device_name=None, device_type=None, device_id=Non
     :param device_id: str or int which matches the specific awair device internal id number
     :return: Object of Dict type which contains current air data
     """
-    if device_name is None:
-        base_url = "http://developer-apis.awair.is/v1/users/self/devices/"
-        dev_url = device_type + "/" + str(device_id)
-        data_url = "/air-data/latest"
-        f_url = base_url + dev_url + data_url
-        #print(f_url)
-        response = requests.get(f_url, headers=auth.headers)
-        return json.loads(response.text)['data']
-    else:
-        devices = get_all_devices(auth)
-        for dev in devices:
-            if dev['name'] == device_name:
-                base_url = "http://developer-apis.awair.is/v1/users/self/devices/"
-                dev_url = dev['deviceType'] + "/" + str(dev['deviceId'])
-                data_url = "/air-data/latest"
-                f_url = base_url + dev_url + data_url
-                #print(f_url)
-                response = requests.get(f_url, headers=auth.headers)
-                return json.loads(response.text)['data']
+    if device_type is None or device_id is None:
+        awair_device = AwairDev(device_name, auth)
+        device_type = awair_device.type()
+        device_id = awair_device.id()
+
+    base_url = "http://developer-apis.awair.is/v1/users/self/devices/"
+    data_url = "/air-data/latest"
+    data = pyawair.conn.get_data(auth, device_id, device_type, base_url, data_url)
+
+    return data
 
 
 def get_5_min_average(auth, device_name=None, device_type=None, device_id=None):
-    if device_name is None:
-        base_url = "http://developer-apis.awair.is/v1/users/self/devices/"
-        dev_url = device_type + "/" + str(device_id)
-        data_url = "/air-data/5-min-avg"
-        f_url = base_url + dev_url + data_url
-        #print(f_url)
-        response = requests.get(f_url, headers=auth.headers)
-        return json.loads(response.text)['data']
-    else:
-        devices = get_all_devices(auth)
-        for dev in devices:
-            if dev['name'] == device_name:
-                base_url = "http://developer-apis.awair.is/v1/users/self/devices/"
-                dev_url = dev['deviceType'] + "/" + str(dev['deviceId'])
-                data_url = "/air-data/5-min-avg"
-                f_url = base_url + dev_url + data_url
-                #print(f_url)
-                response = requests.get(f_url, headers=auth.headers)
-                return json.loads(response.text)['data']
+    """
+    Function to get air data that is averaged over each 5 minutes from a single specific Awair Device linked
+    to your account
+    :param auth: pyawair.auth.AwairAuth object which contains a valid authentication token
+    :param device_type: str which matches the awair device type
+    :param device_name: str which matches exactly to the name of a specific device
+    :param device_id: str or int which matches the specific awair device internal id number
+    :return: Object of Dict type which contains current air data
+    """
+    if device_type is None or device_id is None:
+        awair_device = AwairDev(device_name, auth)
+        device_type = awair_device.type()
+        device_id = awair_device.id()
+
+    base_url = "http://developer-apis.awair.is/v1/users/self/devices/"
+    data_url = "/air-data/5-min-avg"
+    data = pyawair.conn.get_data(auth, device_id, device_type, base_url, data_url)
+
+    return data
 
 
 def get_15_min_average(auth, device_name=None, device_type=None, device_id=None):
-    if device_name is None:
-        base_url = "http://developer-apis.awair.is/v1/users/self/devices/"
-        dev_url = device_type + "/" + str(device_id)
-        data_url = "/air-data/15-min-avg"
-        f_url = base_url + dev_url + data_url
-        #print(f_url)
-        response = requests.get(f_url, headers=auth.headers)
-        return json.loads(response.text)['data']
-    else:
-        devices = get_all_devices(auth)
-        for dev in devices:
-            if dev['name'] == device_name:
-                base_url = "http://developer-apis.awair.is/v1/users/self/devices/"
-                dev_url = dev['deviceType'] + "/" + str(dev['deviceId'])
-                data_url = "/air-data/15-min-avg"
-                f_url = base_url + dev_url + data_url
-                #print(f_url)
-                response = requests.get(f_url, headers=auth.headers)
-                return json.loads(response.text)['data']
+    """
+    Function to get air data that is averaged over each 5 minutes from a single specific Awair Device linked
+    to your account
+    :param auth: pyawair.auth.AwairAuth object which contains a valid authentication token
+    :param device_type: str which matches the awair device type
+    :param device_name: str which matches exactly to the name of a specific device
+    :param device_id: str or int which matches the specific awair device internal id number
+    :return: Object of Dict type which contains current air data
+    """
+    if device_type is None or device_id is None:
+        awair_device = AwairDev(device_name, auth)
+        device_type = awair_device.type()
+        device_id = awair_device.id()
+
+    base_url = "http://developer-apis.awair.is/v1/users/self/devices/"
+    data_url = "/air-data/15-min-avg"
+    data = pyawair.conn.get_data(auth, device_id, device_type, base_url, data_url)
+
+    return data
 
 
 def get_raw_data(auth, device_name=None, device_type=None, device_id=None):
-    if device_name is None:
-        base_url = "http://developer-apis.awair.is/v1/users/self/devices/"
-        dev_url = device_type + "/" + str(device_id)
-        data_url = "/air-data/raw"
-        f_url = base_url + dev_url + data_url
-        #print(f_url)
-        response = requests.get(f_url, headers=auth.headers)
-        return json.loads(response.text)['data']
-    else:
-        devices = get_all_devices(auth)
-        for dev in devices:
-            if dev['name'] == device_name:
-                base_url = "http://developer-apis.awair.is/v1/users/self/devices/"
-                dev_url = dev['deviceType'] + "/" + str(dev['deviceId'])
-                data_url = "/air-data/raw"
-                f_url = base_url + dev_url + data_url
-                #print(f_url)
-                response = requests.get(f_url, headers=auth.headers)
-                return json.loads(response.text)['data']
+    """
+        Function to get air data that is averaged over each 5 minutes from a single specific Awair Device linked
+        to your account
+        :param auth: pyawair.auth.AwairAuth object which contains a valid authentication token
+        :param device_type: str which matches the awair device type
+        :param device_name: str which matches exactly to the name of a specific device
+        :param device_id: str or int which matches the specific awair device internal id number
+        :return: Object of Dict type which contains current air data
+        """
+    if device_type is None or device_id is None:
+        awair_device = AwairDev(device_name, auth)
+        device_type = awair_device.type()
+        device_id = awair_device.id()
+
+    base_url = "http://developer-apis.awair.is/v1/users/self/devices/"
+    data_url = "/air-data/raw"
+    data = pyawair.conn.get_data(auth, device_id, device_type, base_url, data_url)
+
+    return data

--- a/pyawair/devices.py
+++ b/pyawair/devices.py
@@ -58,6 +58,7 @@ def get_dev_led_mode(auth, device_name=None, device_type=None, device_id=None):
         f_url = base_url + dev_url + data_url
         #print(f_url)
         response = requests.get(f_url, headers=auth.headers)
+        pyawair.conn.check_response(response)
         return json.loads(response.text)
     elif device_name is not None:
         devices = get_all_devices(auth)
@@ -69,6 +70,7 @@ def get_dev_led_mode(auth, device_name=None, device_type=None, device_id=None):
                 f_url = base_url + dev_url + data_url
                 #print(f_url)
                 response = requests.get(f_url, headers=auth.headers)
+                pyawair.conn.check_response(response)
                 return json.loads(response.text)
     else:
         return "Device Not Found"
@@ -92,6 +94,7 @@ def get_dev_timezone(auth, device_name=None, device_type=None, device_id=None):
         f_url = base_url + dev_url + data_url
         #print(f_url)
         response = requests.get(f_url, headers=auth.headers)
+        pyawair.conn.check_response(response)
         return json.loads(response.text)
     else:
         devices = get_all_devices(auth)
@@ -103,6 +106,7 @@ def get_dev_timezone(auth, device_name=None, device_type=None, device_id=None):
                 f_url = base_url + dev_url + data_url
                 #print(f_url)
                 response = requests.get(f_url, headers=auth.headers)
+                pyawair.conn.check_response(response)
                 return json.loads(response.text)
 
 
@@ -296,6 +300,7 @@ def set_device_led(auth, led_mode, device_name=None, device_type=None, device_id
                 #print(f_url)
                 data = json.dumps({'mode': led_mode})
                 response = requests.post(f_url, data=data, headers=auth.headers)
+                pyawair.conn.check_response(response)
                 return json.loads(response.text)
         except:
             print("mode setting not valid")
@@ -312,6 +317,7 @@ def set_device_led(auth, led_mode, device_name=None, device_type=None, device_id
                         #print(f_url)
                         data = json.dumps({'mode': led_mode})
                         response = requests.post(f_url, data=data, headers=auth.headers)
+                        pyawair.conn.check_response(response)
                         return json.loads(response.text)
                 except:
                     print("INVALID LED MODE SPECIFIED")

--- a/pyawair/devices.py
+++ b/pyawair/devices.py
@@ -1,5 +1,6 @@
 import json
 import requests
+import pyawair.conn
 
 
 def get_user_data(auth):
@@ -21,6 +22,7 @@ def get_all_devices(auth):
     """
     response = requests.get("http://developer-apis.awair.is/v1/users/self/devices",
                             headers=auth.headers)
+    pyawair.conn.check_response(response)
     return json.loads(response.text)['devices']
 
 

--- a/pyawair/devices.py
+++ b/pyawair/devices.py
@@ -123,6 +123,7 @@ def get_dev_display_mode(auth, device_name=None, device_type=None, device_id=Non
         f_url = base_url + dev_url + data_url
         #print(f_url)
         response = requests.get(f_url, headers=auth.headers)
+        pyawair.conn.check_response(response)
         return json.loads(response.text)
     else:
         devices = get_all_devices(auth)
@@ -134,6 +135,7 @@ def get_dev_display_mode(auth, device_name=None, device_type=None, device_id=Non
                 f_url = base_url + dev_url + data_url
                 #print(f_url)
                 response = requests.get(f_url, headers=auth.headers)
+                pyawair.conn.check_response(response)
                 return json.loads(response.text)
 
 
@@ -154,6 +156,7 @@ def get_dev_power_status(auth, device_name=None, device_type=None, device_id=Non
         f_url = base_url + dev_url + data_url
         #print(f_url)
         response = requests.get(f_url, headers=auth.headers)
+        pyawair.conn.check_response(response)
         return json.loads(response.text)
     else:
         devices = get_all_devices(auth)
@@ -165,6 +168,7 @@ def get_dev_power_status(auth, device_name=None, device_type=None, device_id=Non
                 f_url = base_url + dev_url + data_url
                 #print(f_url)
                 response = requests.get(f_url, headers=auth.headers)
+                pyawair.conn.check_response(response)
                 return json.loads(response.text)
 
 
@@ -196,6 +200,7 @@ def set_device_preference(auth, new_mode, device_name=None, device_type=None, de
                 #print(f_url)
                 data = json.dumps({'pref': new_mode})
                 response = requests.put(f_url, data=data, headers=auth.headers)
+                pyawair.conn.check_response(response)
                 return json.loads(response.text)
         except:
             print("mode setting not valid")
@@ -213,6 +218,7 @@ def set_device_preference(auth, new_mode, device_name=None, device_type=None, de
                     #print(f_url)
                     data = json.dumps({'pref': new_mode})
                     response = requests.put(f_url, data=data, headers=auth.headers)
+                    pyawair.conn.check_response(response)
                     return json.loads(response.text)
 
 
@@ -243,6 +249,7 @@ def set_device_timezone(auth, timezone, device_name=None, device_type=None, devi
             #print(f_url)
             data = json.dumps({'timezone': timezone})
             response = requests.post(f_url, data=data, headers=auth.headers)
+            pyawair.conn.check_response(response)
             return json.loads(response.text)
         except:
             print("mode setting not valid")
@@ -257,6 +264,7 @@ def set_device_timezone(auth, timezone, device_name=None, device_type=None, devi
                 #print(f_url)
                 data = json.dumps({'timezone': timezone})
                 response = requests.post(f_url, data=data, headers=auth.headers)
+                pyawair.conn.check_response(response)
                 return json.loads(response.text)
 
 

--- a/pyawair/objects.py
+++ b/pyawair/objects.py
@@ -54,6 +54,14 @@ class AwairDev:
             self.refresh()
         return(self._data[indicator])
 
+    def name(self) -> str:
+        """
+        Function to get the name of the device.
+
+        :return: The name of the device.
+        """
+        return(self._device_name)
+
     def refresh(self):
         """
         Function to refresh the state of the objects.

--- a/pyawair/objects.py
+++ b/pyawair/objects.py
@@ -4,8 +4,7 @@
 # author: @netmanchris
 # -*- coding: utf-8 -*-
 
-from pyawair.data import get_current_air_data, get_15_min_average, get_5_min_average
-from pyawair.data import get_all_devices
+import pyawair.data
 from pyawair.auth import AwairAuth
 import datetime
 
@@ -33,7 +32,7 @@ class AwairDev:
         self._device_name = device_name
 
         # Get device type and ID from name
-        devices = get_all_devices(self._auth)
+        devices = pyawair.data.get_all_devices(self._auth)
         self._type = next((item for item in devices if item["name"] == device_name),
                           False)['deviceType']  # get the device type
         self._id = next((item for item in devices if item["name"] == device_name),
@@ -93,11 +92,11 @@ class AwairDev:
         refresh.
         """
         if self._aggregate_type == 'current':
-            data: list = get_current_air_data(self._auth, device_id=self._id, device_type=self._type)
+            data: list = pyawair.data.get_current_air_data(self._auth, device_id=self._id, device_type=self._type)
         elif self._aggregate_type == '5-minute':
-            data: list = get_5_min_average(self._auth, device_id=self._id, device_type=self._type)
+            data: list = pyawair.data.get_5_min_average(self._auth, device_id=self._id, device_type=self._type)
         elif self._aggregate_type == '15-minute':
-            data: list = get_15_min_average(self._auth, device_id=self._id, device_type=self._type)
+            data: list = pyawair.data.get_15_min_average(self._auth, device_id=self._id, device_type=self._type)
 
         self._data['score'] = data[0]['score']
         self._data['temp'] = data[0]['sensors'][0]['value']

--- a/pyawair/objects.py
+++ b/pyawair/objects.py
@@ -4,13 +4,13 @@
 # author: @netmanchris
 # -*- coding: utf-8 -*-
 
-from pyawair.data import get_current_air_data
+from pyawair.data import get_current_air_data, get_15_min_average, get_5_min_average
 from pyawair.data import get_all_devices
 from pyawair.auth import AwairAuth
 import datetime
 
 class AwairDev:
-    def __init__(self, device_name: str, auth: AwairAuth, cache_time: float = 15):
+    def __init__(self, device_name: str, auth: AwairAuth, cache_time: float = 15, aggregate_type = '15-minute'):
         """
         Initialise AwairDev object.
 
@@ -19,9 +19,15 @@ class AwairDev:
         :param cache_time: The time in minutes that the state values should be cached. When this time has expired, new values
                            will be requested. Keep in mind that the API has daily limits so setting this too low might
                            cause problems.
+        :param aggregate_type: Type can be 'current', '5-minute' or '15-minute' referring to the aggregation. Keep in mind that
+                               not all tiers have access to all of them.
         """
         self._auth = auth
         self._cache_time = cache_time
+        if aggregate_type in ['current', '5-minute', '15-minute']:
+            self._aggregate_type = aggregate_type
+        else:
+            raise ValueError("The argument aggregate_type cannot have this value.")
         self._last_update = datetime.datetime.now()  # records the last update
 
         self._device_name = device_name
@@ -86,12 +92,18 @@ class AwairDev:
         time value. The refresh function refreshed these values, independent of the time that has past since the last
         refresh.
         """
-        current_data: list = get_current_air_data(self._auth, device_id=self._id, device_type=self._type)
-        self._data['score'] = current_data[0]['score']
-        self._data['temp'] = current_data[0]['sensors'][0]['value']
-        self._data['humid'] = current_data[0]['sensors'][1]['value']
-        self._data['co2'] = current_data[0]['sensors'][2]['value']
-        self._data['voc'] = current_data[0]['sensors'][3]['value']
-        self._data['dust'] = current_data[0]['sensors'][4]['value']
+        if self._aggregate_type == 'current':
+            data: list = get_current_air_data(self._auth, device_id=self._id, device_type=self._type)
+        elif self._aggregate_type == '5-minute':
+            data: list = get_5_min_average(self._auth, device_id=self._id, device_type=self._type)
+        elif self._aggregate_type == '15-minute':
+            data: list = get_15_min_average(self._auth, device_id=self._id, device_type=self._type)
+
+        self._data['score'] = data[0]['score']
+        self._data['temp'] = data[0]['sensors'][0]['value']
+        self._data['humid'] = data[0]['sensors'][1]['value']
+        self._data['co2'] = data[0]['sensors'][2]['value']
+        self._data['voc'] = data[0]['sensors'][3]['value']
+        self._data['dust'] = data[0]['sensors'][4]['value']
         self._last_update = datetime.datetime.now()  # records the time of the last update
 

--- a/pyawair/objects.py
+++ b/pyawair/objects.py
@@ -62,6 +62,22 @@ class AwairDev:
         """
         return(self._device_name)
 
+    def type(self) -> str:
+        """
+        Function to get the name of the device.
+
+        :return: The type of the device.
+        """
+        return(self._type)
+
+    def id(self) -> str:
+        """
+        Function to get the name of the device.
+
+        :return: The name of the device.
+        """
+        return(self._id)
+
     def refresh(self):
         """
         Function to refresh the state of the objects.

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,0 +1,12 @@
+TEST_DEVICE_NAME = None
+TEST_TOKEN = None
+
+def get_test_token():
+    if TEST_TOKEN is None:
+        raise ValueError("Invalid token")
+    return TEST_TOKEN
+
+def get_test_device_name():
+    if TEST_DEVICE_NAME is None:
+        raise ValueError("Invalid token")
+    return TEST_DEVICE_NAME

--- a/tests/config.py
+++ b/tests/config.py
@@ -8,5 +8,5 @@ def get_test_token():
 
 def get_test_device_name():
     if TEST_DEVICE_NAME is None:
-        raise ValueError("Invalid token")
+        raise ValueError("Invalid name")
     return TEST_DEVICE_NAME

--- a/tests/test_pyawair_data.py
+++ b/tests/test_pyawair_data.py
@@ -6,17 +6,17 @@ This module is used for testing the functions within the pyhpeimc.plat.alarms mo
 from unittest import TestCase
 from secret import *
 from pyawair.data import *
+from tests.config import get_test_token, get_test_device_name
 
-#dev1="Bedroom Awair"   #Modify this variable to test against your own devices
-dev1="Bedroom Glow"
-
+dev1 = get_test_device_name()
+auth = pyawair.auth.AwairAuth(get_test_token())
 
 # TODO Remarked out failing tests
 
 
 class TestGetCurrentAirData(TestCase):
     """
-    Test Case for pyawair.devices get_current_air_data function
+    Test Case for pyawair.data get_current_air_data function
     """
 
     def test_get_current_air(self):

--- a/tests/test_pyawair_devices.py
+++ b/tests/test_pyawair_devices.py
@@ -6,10 +6,11 @@ This module is used for testing the functions within the pyhpeimc.plat.alarms mo
 from unittest import TestCase
 from secret import *
 from pyawair.devices import *
+import pyawair.auth
+from tests.config import get_test_token, get_test_device_name
 
-dev1="Bedroom Awair"   #Modify this variable to test against your own devices
-
-
+dev1 = get_test_device_name()
+auth = pyawair.auth.AwairAuth(get_test_token())
 
 # TODO Remarked out failing tests
 


### PR DESCRIPTION
This pull request adds three things:
1. New code to the objects file to differentiate between the various calls (current, 5 min or 15 min).
2. For the data and device queries, it adds a check on the response. When the status code is not 200, it throws and error. This is more clear than a 'No keyword: data' error on the next line.
3. To help with step two, I did a bit of general refactoring. 
    * There was some code duplication in the get_data functions. This code now lives in a separate function. 
    * At the same time I've also used the AwairDev object to clean up the name checking when the ID and type is needed.
    * Finally I've added some docstrings for the get_data functions.

Have a look and let me know what you think. For your reference, step one is needed as a fix to make it work again. Step two was needed to make the error more clear, but is not needed in the bugfix.