### PR TITLE
Add ability to set additional API parameters

### DIFF
--- a/pyawair/conn.py
+++ b/pyawair/conn.py
@@ -17,7 +17,7 @@ def check_response(response):
     return
 
 
-def get_data(auth, id, type, base_url, data_url, args=''):
+def get_data(auth, id, type, base_url, data_url, args='', params=None):
     """
     Builds the Awair API string and returns the response.
     :param auth: Authentication object as created by pyawair.auth.AwairAuth
@@ -25,13 +25,14 @@ def get_data(auth, id, type, base_url, data_url, args=''):
     :param type: The Awair Type
     :param base_url: The basic URL to the Awair API ("https://developer-apis.awair.is/v1/users/self/devices/")
     :param data_url: The data URL contains the specific data for a specific query (e.g. "/air-data/5-min-avg")
-    :param args: Optional arguments
+    :param args: Optional arguments to add to the URL
+    :param params: Optional dictionary of API parameters
     :return: The response from the Awair API, as a JSON object.
     """
     dev_url = type + "/" + str(id)
     f_url = base_url + dev_url + data_url + args
 
-    response = requests.get(f_url, headers=auth.headers) # Get the response from this URL
+    response = requests.get(f_url, headers=auth.headers, params=params) # Get the response from this URL
     check_response(response) # check if the response satisfies normal API results. If it doesn't it throws an error.
 
     return json.loads(response.text)['data']

--- a/pyawair/data.py
+++ b/pyawair/data.py
@@ -88,7 +88,7 @@ def get_15_min_average(auth, device_name=None, device_type=None, device_id=None,
     return data
 
 
-def get_raw_data(auth, device_name=None, device_type=None, device_id=None):
+def get_raw_data(auth, device_name=None, device_type=None, device_id=None, params=None):
     """
         Function to get air data that is averaged over each 5 minutes from a single specific
         Awair Device linked
@@ -97,6 +97,7 @@ def get_raw_data(auth, device_name=None, device_type=None, device_id=None):
         :param device_type: str which matches the awair device type
         :param device_name: str which matches exactly to the name of a specific device
         :param device_id: str or int which matches the specific awair device internal id number
+        :param params: Optional dictionary of API parameters
         :return: Object of Dict type which contains current air data
         """
     if device_type is None or device_id is None:
@@ -106,6 +107,6 @@ def get_raw_data(auth, device_name=None, device_type=None, device_id=None):
 
     base_url = "https://developer-apis.awair.is/v1/users/self/devices/"
     data_url = "/air-data/raw"
-    data = pyawair.conn.get_data(auth, device_id, device_type, base_url, data_url)
+    data = pyawair.conn.get_data(auth, device_id, device_type, base_url, data_url, params=params)
 
     return data


### PR DESCRIPTION
Hi @netmanchris,

Thanks for the great library.

Please review this PR - I added ability to set additional API parameters in conn.get_data() and data.get_raw_data().

One of the possible application example - filter raw data by date/time.

Thanks,

Andrii